### PR TITLE
Wait until program finishes before closing STDIN

### DIFF
--- a/tanco/runner.py
+++ b/tanco/runner.py
@@ -95,7 +95,6 @@ def send_cmds(cfg: Config, program, ilines):
         for cmd in ilines:
             program.stdin.write(cmd + "\n")
             program.stdin.flush()
-        program.stdin.close()
 
 
 def run_test(cfg: Config, program: subprocess.Popen, test: TestDescription):
@@ -103,6 +102,8 @@ def run_test(cfg: Config, program: subprocess.Popen, test: TestDescription):
     send_cmds(cfg, program, test.ilines)
     # listen for the response:
     (actual, _errs) = program.communicate(timeout=5)
+    program.wait()
+    program.stdin.close()
     # TODO: handle errors in the `errs` string
     actual = clean_output(cfg, actual)
     local_check_output(cfg, actual, test)

--- a/tanco/runner.py
+++ b/tanco/runner.py
@@ -102,8 +102,6 @@ def run_test(cfg: Config, program: subprocess.Popen, test: TestDescription):
     send_cmds(cfg, program, test.ilines)
     # listen for the response:
     (actual, _errs) = program.communicate(timeout=5)
-    program.wait()
-    program.stdin.close()
     # TODO: handle errors in the `errs` string
     actual = clean_output(cfg, actual)
     local_check_output(cfg, actual, test)


### PR DESCRIPTION
This seems to fix the problem I was seeing (in Linux when testing a Nim program):

```
Traceback (most recent call last):
  File "/home/omf/.local/lib/python3.10/site-packages/tanco/runner.py", line 276, in main
    run_tests(cfg)
  File "/home/omf/.local/lib/python3.10/site-packages/tanco/runner.py", line 161, in run_tests
    run_test(cfg, program, test)
  File "/home/omf/.local/lib/python3.10/site-packages/tanco/runner.py", line 105, in run_test
    (actual, _errs) = program.communicate(timeout=5)
  File "/usr/lib/python3.10/subprocess.py", line 1154, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/usr/lib/python3.10/subprocess.py", line 1973, in _communicate
    self.stdin.flush()
ValueError: I/O operation on closed file.
```

However, it will probably break the `if cfg.input_path:` branch of `send_cmds` -- I don't know how that bit is supposed to work.